### PR TITLE
Add Elixir language support

### DIFF
--- a/app/config/languages.ts
+++ b/app/config/languages.ts
@@ -10,6 +10,7 @@ export const validLanguages = [
   'ruby',
   'swift',
   'sql',
+  'elixir',
 ] as const;
 
 export type ValidLanguage = (typeof validLanguages)[number];
@@ -26,4 +27,5 @@ export const languageDisplayNames: Record<ValidLanguage, string> = {
   ruby: 'Ruby',
   swift: 'Swift',
   sql: 'SQL',
+  elixir: 'Elixir',
 };


### PR DESCRIPTION
This PR adds Elixir as a supported language for syntax highlighting.

Fixes #2

Changes made:
- Added 'elixir' to the list of valid languages
- Added Elixir display name mapping

Testing:
- [ ] Verify Elixir appears in the language selection dropdown
- [ ] Verify syntax highlighting works correctly for Elixir code