### PR TITLE
Change Update Password button text to Change Password

### DIFF
--- a/app/routes/_dashboard.settings.tsx
+++ b/app/routes/_dashboard.settings.tsx
@@ -225,7 +225,7 @@ function SettingsPage() {
                 )}
               />
               <Button type="submit" size="sm">
-                Update Password
+                Change Password
               </Button>
             </form>
           </Form>


### PR DESCRIPTION
Fixes #4

Changed the button text from "Update Password" to "Change Password" on the settings page to make it more consistent with the section title.