### PR TITLE
Fix version and fork text color in light mode

### DIFF
--- a/app/routes/_dashboard/gists/$id/index.tsx
+++ b/app/routes/_dashboard/gists/$id/index.tsx
@@ -115,14 +115,14 @@ function RouteComponent() {
                 : 'No language'}
             </span>
             <span className="text-gray-300 hidden sm:inline">•</span>
-            <span className="text-gray-300">
+            <span className="text-gray-600 dark:text-gray-300">
               {gist.versions.length} version
               {gist.versions.length !== 1 ? 's' : ''}
             </span>
             {gist.forkedFrom && (
               <>
                 <span className="text-gray-300 hidden sm:inline">•</span>
-                <span className="text-gray-300">
+                <span className="text-gray-600 dark:text-gray-300">
                   Forked from{' '}
                   <Link
                     to="/gists/$id/share"
@@ -137,7 +137,7 @@ function RouteComponent() {
             {gist.forksCount > 0 && (
               <>
                 <span className="text-gray-300 hidden sm:inline">•</span>
-                <span className="text-gray-300">
+                <span className="text-gray-600 dark:text-gray-300">
                   {gist.forksCount} fork{gist.forksCount !== 1 ? 's' : ''}
                 </span>
               </>

--- a/app/routes/_dashboard/index.tsx
+++ b/app/routes/_dashboard/index.tsx
@@ -140,7 +140,7 @@ function Home() {
                       <h2 className="text-lg font-semibold truncate">
                         {gist.title}
                       </h2>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-muted-foreground">
                         <span>{gist.language || 'No language'}</span>
                         <span>•</span>
                         <span>

--- a/app/routes/gists/$id.share.tsx
+++ b/app/routes/gists/$id.share.tsx
@@ -106,7 +106,7 @@ function RouteComponent() {
                 : 'No language'}
             </span>
             <span className="text-gray-300">•</span>
-            <span className="text-gray-300">
+            <span className="text-gray-600 dark:text-gray-300">
               {gist.versions.length} version
               {gist.versions.length !== 1 ? 's' : ''}
             </span>


### PR DESCRIPTION
This PR fixes issue #14 by adjusting the text color of version and fork text to be more visible in light mode.

Changes made:
- Updated text color classes to use `text-gray-600` in light mode and `dark:text-gray-300` or `dark:text-muted-foreground` in dark mode
- Applied changes consistently across all pages where version and fork text appears

This ensures better readability in light mode while maintaining the current appearance in dark mode.

Fixes #14